### PR TITLE
Fix Deploy Action for private repos

### DIFF
--- a/.github/workflows/deployflow.yml
+++ b/.github/workflows/deployflow.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build-and-deploy-app:
     permissions:
+      contents: read
       pages: write
       id-token: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reason: https://github.com/actions/checkout/issues/254#issuecomment-1766695787

TL;DR: 'permissions' overwrite defaults, and because of this, the action can't fetch itself if it's private repo.